### PR TITLE
Updates to be able to run and push app to PaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ How to start the dropwizard-example application
 ---
 
 1. Run `./gradlew build` to build the application
-1. Start application with `java -jar target/dropwizard-example-1.0-SNAPSHOT.jar server config.yml`
+1. Start application with `./gradlew run`
 1. To check that your application is running enter url `http://localhost:8080`
 1. To deploy, run `cf push`
 

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -15,7 +15,7 @@ ext {
             "io.dropwizard.metrics:metrics-graphite:${dropwizard_metrics_version}"
     ]
 
-    dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_45"
+    dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.2.0-build_50"
 
     dropwizardPrometheus = [
             'uk.gov.reng:gds_metrics_dropwizard:1.0.0'

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: dropwizard-example
-  memory: 512M
+  memory: 1G
   buildpack: java_buildpack
   path: build/distributions/dropwizard-example.zip
   env:


### PR DESCRIPTION
Updates to be able to run and push app to PaaS

1 - Updated the README on how to run the app
2 - Increased memory requirement in manifest file
3 - Updated logstash dependency to latest (this was probably not required)

Please see individual commits for more details.

Arguably, I could have created a PR for each of those changes, as they don't relate to each other. However, I felt this was a good trade-off.

N.B.: in order to have the app running, in the limited time available, I also used this work-around https://github.com/alphagov/dropwizard-example/pull/4 (fetching Prometheus dependency from my local Maven repo).