### PR TITLE
Running app using Maven local for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 How to start the dropwizard-example application
 ---
 
+1. Push the Prometheus dependency to your local Maven repository - see README here [`dropwizardPrometheus`](https://github.com/alphagov/gds_metrics_dropwizard)
 1. Run `./gradlew build` to build the application
 1. Start application with `java -jar target/dropwizard-example-1.0-SNAPSHOT.jar server config.yml`
 1. To check that your application is running enter url `http://localhost:8080`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 How to start the dropwizard-example application
 ---
 
-1. Push the Prometheus dependency to your local Maven repository - see README here [`dropwizardPrometheus`](https://github.com/alphagov/gds_metrics_dropwizard)
 1. Run `./gradlew build` to build the application
 1. Start application with `java -jar target/dropwizard-example-1.0-SNAPSHOT.jar server config.yml`
 1. To check that your application is running enter url `http://localhost:8080`

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ task wrapper(type: Wrapper) {
 
 repositories {
     mavenCentral()
-    mavenLocal()
     maven {
         url 'https://dl.bintray.com/alphagov/maven'
     }

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -17,7 +17,7 @@ ext {
 
     dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_45"
 
-    dropwizardPrometheus = "engineering.gds-reliability:gds_metrics_dropwizard:0.0.1"
+    dropwizardPrometheus = "engineering.gds-reliability:gds-metrics-dropwizard:0.0.1"
 
     // test dependencies
     dropwizardTest = "io.dropwizard:dropwizard-testing:${dropwizard_version}"

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -17,9 +17,7 @@ ext {
 
     dropwizardLogstash = "uk.gov.ida:dropwizard-logstash:1.1.2-build_45"
 
-    dropwizardPrometheus = [
-            'uk.gov.reng:gds_metrics_dropwizard:1.0.0'
-    ]
+    dropwizardPrometheus = "engineering.gds-reliability:gds_metrics_dropwizard:0.0.1"
 
     // test dependencies
     dropwizardTest = "io.dropwizard:dropwizard-testing:${dropwizard_version}"

--- a/src/main/java/uk/gov/ExampleApplication.java
+++ b/src/main/java/uk/gov/ExampleApplication.java
@@ -12,9 +12,9 @@ import io.prometheus.client.exporter.MetricsServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
-import uk.gov.reng.metrics.bundle.MetricsBundle;
-import uk.gov.reng.metrics.config.Configuration;
-import uk.gov.reng.metrics.filter.AuthenticationFilter;
+import engineering.reliability.gds.metrics.bundle.MetricsBundle;
+import engineering.reliability.gds.metrics.config.Configuration;
+import engineering.reliability.gds.metrics.filter.AuthenticationFilter;
 import uk.gov.resources.HelloWorld;
 
 import javax.servlet.DispatcherType;


### PR DESCRIPTION
This is just  a work-around to be able to run this demo app using Maven local for the Prometheus dependency.

The actually long-term solution is to have the Prometheus dependency hosted on Bintray.

Please, feel free to:
1) close this PR
2) keep it open for reference
3) merge it, as a short-term solution while implementing the long term solution mentioned above.